### PR TITLE
Support Customer Managed Key VM

### DIFF
--- a/policies/vm_scan.json
+++ b/policies/vm_scan.json
@@ -33,11 +33,11 @@
           "kms:GrantIsForAWSResource": "true"
         },
         "StringLike": {
-          "kms:GranteePrincipal": "ec2.*.amazonaws.com",
           "kms:EncryptionContext:aws:ebs:id": [
             "snap-*",
             "vol-*"
-          ]
+          ],
+          "kms:ViaService": "ec2.*.amazonaws.com"
         },
         "ForAllValues:StringEquals": {
           "kms:GrantOperations": [

--- a/policies/vm_scan.json
+++ b/policies/vm_scan.json
@@ -29,13 +29,25 @@
     },
     {
       "Condition": {
+        "Bool": {
+          "kms:GrantIsForAWSResource": "true"
+        },
         "StringLike": {
           "kms:GranteePrincipal": "ec2.*.amazonaws.com",
-          "kms:EncryptionContext:aws:ebs:id": "snap-*"
+          "kms:EncryptionContext:aws:ebs:id": [
+            "snap-*",
+            "vol-*"
+          ]
         },
         "ForAllValues:StringEquals": {
           "kms:GrantOperations": [
             "Decrypt"
+          ]
+        },
+        "ForAnyValue:StringEquals": {
+          "kms:GrantConstraintType": [
+            "EncryptionContextEquals",
+            "EncryptionContextSubset"
           ]
         }
       },


### PR DESCRIPTION
- VMのCMK対応に伴いスキャンポリシーの以下アップデートを実施
  - `GranteePrincipal` ではなく `GrantIsForAWSResource` を使用
  - CMKのEBSのCopySnapshotでは暗号化コンテキストが `vol-*` も使用されていたため追加
  - 暗号化コンテキストの指定を必須化