### PR TITLE
add elasticmapreduce:List*

### DIFF
--- a/policies/cspm_read_1.json
+++ b/policies/cspm_read_1.json
@@ -57,6 +57,7 @@
         "elasticbeanstalk:ValidateConfigurationSettings",
         "elasticfilesystem:DescribeAccessPoints",
         "elasticfilesystem:ListTagsForResource",
+        "elasticmapreduce:List*",
         "elastictranscoder:List*",
         "elastictranscoder:ReadPipeline",
         "elastictranscoder:ReadPreset",


### PR DESCRIPTION
elasticmapreduce:List*の権限を追加

elasticmapreduce:List*によって追加される権限は以下。

[ListBootstrapActions](https://docs.aws.amazon.com/emr/latest/APIReference/API_ListBootstrapActions.html) クラスターに関連付けられたブートストラップアクションの詳細を取得すためのアクセス許可を付与
[ListEditors](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-managed-notebooks-working-with.html) [アクセス許可のみ] アクセス可能な EMR Notebooks の概要情報をリストするためのアクセス許可を付与
[ListInstanceFleets](https://docs.aws.amazon.com/emr/latest/APIReference/API_ListInstanceFleets.html) クラスター内のインスタンスフリートの詳細を取得するためのアクセス許可を付与
[ListInstanceGroups](https://docs.aws.amazon.com/emr/latest/APIReference/API_ListInstanceGroups.html) クラスター内のインスタンスグループの詳細を取得するためのアクセス許可を付与
[ListNotebookExecutions](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-managed-notebooks-headless.html) ノートブック実行についての概要情報をリストするためのアクセス許可を付与
[ListReleaseLabels](https://docs.aws.amazon.com/emr/latest/APIReference/API_ListReleaseLabels.html) 現在のリージョンで使用可能な EMR リリースを、リストしてフィルタリングするためのアクセス許可を付与
[ListRepositories](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-managed-notebooks.html#emr-managed-notebooks-editor) [アクセス許可のみ] 既存の EMR Notebooksリポジトリをリストするためのアクセス許可を付与
[ListSteps](https://docs.aws.amazon.com/emr/latest/APIReference/API_ListSteps.html) クラスターに関連付けられているステップをリストするためのアクセス許可を付与
[ListStudioSessionMappings](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-studio.html) EMR Studio のセッションマッピングに関する概要情報をリストするためのアクセス許可を付与
[ListStudios](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-studio.html) EMR Studios に関する概要情報をリストするためのアクセス許可を付与
[ListSupportedInstanceTypes](https://docs.aws.amazon.com/emr/latest/APIReference/API_ListSupportedInstanceTypes.html) Amazon EMR リリースがサポートする Amazon EC2 インスタンスタイプを一覧表示するアクセス許可を付与します
[ListWorkspaceAccessIdentities](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-managed-notebooks-working-with.html) [アクセス許可のみ] ワークスペースへのアクセス許可を付与アイデンティティを一覧表示するアクセス許可を付与

