### PR TITLE
move route53profiles, rum, and s3-object-lambda permissions to cspm_read_3

### DIFF
--- a/policies/cspm_read_2.json
+++ b/policies/cspm_read_2.json
@@ -191,20 +191,7 @@
         "route53domains:CheckDomainTransferability",
         "route53domains:GetContactReachabilityStatus",
         "route53domains:GetDomainSuggestions",
-        "route53domains:ListPrices",
-        "route53profiles:GetProfile",
-        "route53profiles:GetProfileAssociation",
-        "route53profiles:GetProfileResourceAssociation",
-        "route53profiles:List*",
-        "rum:GetAppMonitor",
-        "rum:ListAppMonitors",
-        "s3-object-lambda:GetObjectAcl",
-        "s3-object-lambda:GetObjectLegalHold",
-        "s3-object-lambda:GetObjectRetention",
-        "s3-object-lambda:GetObjectTagging",
-        "s3-object-lambda:GetObjectVersionAcl",
-        "s3-object-lambda:GetObjectVersionTagging",
-        "s3-object-lambda:List*"
+        "route53domains:ListPrices"
       ],
       "Resource": "*",
       "Effect": "Allow"

--- a/policies/cspm_read_3.json
+++ b/policies/cspm_read_3.json
@@ -3,6 +3,19 @@
   "Statement": [
     {
       "Action": [
+        "route53profiles:GetProfile",
+        "route53profiles:GetProfileAssociation",
+        "route53profiles:GetProfileResourceAssociation",
+        "route53profiles:List*",
+        "rum:GetAppMonitor",
+        "rum:ListAppMonitors",
+        "s3-object-lambda:GetObjectAcl",
+        "s3-object-lambda:GetObjectLegalHold",
+        "s3-object-lambda:GetObjectRetention",
+        "s3-object-lambda:GetObjectTagging",
+        "s3-object-lambda:GetObjectVersionAcl",
+        "s3-object-lambda:GetObjectVersionTagging",
+        "s3-object-lambda:List*",
         "s3-outposts:GetAccessPoint",
         "s3-outposts:GetAccessPointPolicy",
         "s3-outposts:GetBucket",


### PR DESCRIPTION
## Summary
Relocate `route53profiles`, `rum`, and `s3-object-lambda` read permissions from `cspm_read_2.json` to `cspm_read_3.json`.

## Changes
- Remove `route53profiles:*`, `rum:*`, and `s3-object-lambda:*` actions from `policies/cspm_read_2.json`
- Add the same actions to `policies/cspm_read_3.json`